### PR TITLE
Only attempt to push when there are new commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Fix and document push to custom branch feature #3
+- Only attempt to push when there are new commits #2
 
 ## 1.0.0 - 2018-12-03
 ### Added

--- a/bin/git-gau-exec
+++ b/bin/git-gau-exec
@@ -42,4 +42,8 @@ export GIT_WORK_TREE GIT_DIR
 
 # Push results (if any).
 BRANCH="${GAU_PUSH_BRANCH:-$(${GIT} rev-parse --abbrev-ref HEAD)}"
-${ECHO} "${GAU_PUSH_ARGS:---quiet}" -- origin "HEAD:${BRANCH}" | ${XARGS} ${GIT} push
+BRANCHHASH=$(${GIT} rev-parse "origin/${BRANCH}" 2>/dev/null || ${ECHO})
+HEADHASH="$(${GIT} rev-parse HEAD)"
+if [ -z "$BRANCHHASH" ] || [ "${HEADHASH}" != "${BRANCHHASH}" ]; then
+    ${ECHO} "${GAU_PUSH_ARGS:---quiet}" -- origin "HEAD:${BRANCH}" | ${XARGS} ${GIT} push
+fi


### PR DESCRIPTION
After `command` was executed, `git-gau-exec` attempts to `push` all changes to the remote repository. This operation fails if the remote is read-only. Hence, the `push` only should be performed if `command` resulted in new commits in the temporary working copy.