### PR TITLE
Fix and document push to custom branch feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- ...
+- Fix and document push to custom branch feature #3
 
 ## 1.0.0 - 2018-12-03
 ### Added

--- a/bin/git-gau-exec
+++ b/bin/git-gau-exec
@@ -42,4 +42,4 @@ export GIT_WORK_TREE GIT_DIR
 
 # Push results (if any).
 BRANCH="${GAU_PUSH_BRANCH:-$(${GIT} rev-parse --abbrev-ref HEAD)}"
-${ECHO} "${GAU_PUSH_ARGS:---quiet}" -- origin "${BRANCH}" | ${GIT} push
+${ECHO} "${GAU_PUSH_ARGS:---quiet}" -- origin "HEAD:${BRANCH}" | ${XARGS} ${GIT} push

--- a/doc/git-gau-exec.1.md
+++ b/doc/git-gau-exec.1.md
@@ -34,6 +34,10 @@ GAU\_CLONE\_ARGS
 :   Specify additional arguments for the *git clone* command. Defaults to
     *--quiet*.
 
+GAU\_PUSH\_BRANCH
+:   Specify a custom branch where changes are pushed to. Defaults to currently
+    checked out branch.
+
 GAU\_PUSH\_ARGS
 :   Specify additional arguments for the *git push* command. Defaults to
     *--quiet*.

--- a/test/gauexec.py
+++ b/test/gauexec.py
@@ -89,3 +89,52 @@ class ExecTestCase(unittest.TestCase):
         self.assertEqual(prevauthor, b'Test\n')
         prevmail = self._cmd('git', 'show', '--no-patch', '--format=%ae', 'HEAD^')
         self.assertEqual(prevmail, b'test@localhost\n')
+
+    def testCommitAndPushNewBranch(self):
+        """
+        Simple script no changes, push to new branch.
+        """
+        env = os.environ.copy()
+        env.update({
+            'GIT_COMMITTER_NAME': 'Test Committer',
+            'GIT_COMMITTER_EMAIL': 'committer@localhost',
+            'GIT_AUTHOR_NAME': 'Test Author',
+            'GIT_AUTHOR_EMAIL': 'author@localhost',
+            'GAU_PUSH_BRANCH': 'feature/master/updates-123'
+        })
+
+        script = 'git commit --quiet --allow-empty -m "Branch commit"'
+        self._cmd('git', 'gau-exec', self.repodir,
+                           '/bin/sh', '-c', script, env=env)
+
+        logs = self._cmd('git', 'log', '--format=%s', 'master')
+        self.assertEqual(logs, b'Initial commit\n')
+
+        logs = self._cmd('git', 'log', '--format=%s', 'feature/master/updates-123')
+        self.assertEqual(logs, b'Branch commit\nInitial commit\n')
+
+        curauthor = self._cmd('git', 'show', '--no-patch', '--format=%an', 'feature/master/updates-123')
+        self.assertEqual(curauthor, b'Test Author\n')
+        curmail = self._cmd('git', 'show', '--no-patch', '--format=%ae', 'feature/master/updates-123')
+        self.assertEqual(curmail, b'author@localhost\n')
+
+        prevauthor = self._cmd('git', 'show', '--no-patch', '--format=%an', 'feature/master/updates-123^')
+        self.assertEqual(prevauthor, b'Test\n')
+        prevmail = self._cmd('git', 'show', '--no-patch', '--format=%ae', 'feature/master/updates-123^')
+        self.assertEqual(prevmail, b'test@localhost\n')
+
+    def testCheckoutAndPushNewBranch(self):
+        """
+        Simple script no changes, push to new branch.
+        """
+        env = os.environ.copy()
+
+        script = 'git checkout -b feature/master/bells-and-whistles'
+        self._cmd('git', 'gau-exec', self.repodir,
+                           '/bin/sh', '-c', script, env=env)
+
+        logs = self._cmd('git', 'log', '--format=%s', 'master')
+        self.assertEqual(logs, b'Initial commit\n')
+
+        logs = self._cmd('git', 'log', '--format=%s', 'feature/master/bells-and-whistles')
+        self.assertEqual(logs, b'Initial commit\n')


### PR DESCRIPTION
After `command` was executed, `git-gau-exec` is supposed to push all changes to the branch specified in `GAU_PUSH_BRANCH` environment variable. This use case is neither covered by automated tests nor documented. Also it looks like it is actually defect since the script is lacking a call to `xargs` and as a result the call to `git push` is not properly parametrized.